### PR TITLE
fix: unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
   },
   settings: {
     react: {

--- a/src/components/GridImageList/GridImageList.tsx
+++ b/src/components/GridImageList/GridImageList.tsx
@@ -20,7 +20,7 @@ interface SkeletonProps {
   items: number;
 }
 
-const CardSkeleton = ({ items }: SkeletonProps) => {
+const CardSkeleton: React.FC<SkeletonProps> = ({ items }) => {
   const cards = new Array(items).fill(null);
   return (
     <React.Fragment>
@@ -43,7 +43,9 @@ const CardSkeleton = ({ items }: SkeletonProps) => {
   );
 };
 
-const CardList = ({ list }: CardListProps<ArtObjectResponseProps>) => {
+const CardList: React.FC<CardListProps<ArtObjectResponseProps>> = ({
+  list,
+}) => {
   return (
     <React.Fragment>
       {list.map(el => (
@@ -92,10 +94,7 @@ const CardList = ({ list }: CardListProps<ArtObjectResponseProps>) => {
 
 export const GridImageList: React.FC<
   GridImageListProps<CollectionResponseProps>
-> = ({
-  data,
-  loading = false,
-}: GridImageListProps<CollectionResponseProps>) => {
+> = ({ data, loading = false }) => {
   const { artObjects, count } = data;
   const totalResults = count > 0 ? `${count} results` : '';
   const hasResults = count > 0;

--- a/src/components/ListResults/ListResults.tsx
+++ b/src/components/ListResults/ListResults.tsx
@@ -53,7 +53,7 @@ const NoResultsLayout = () => {
 
 export const ListResults: React.FC<ListResultsProps> = ({
   viewStyle = ViewStyles.Grid,
-}: ListResultsProps) => {
+}) => {
   const TITLE = 'Artwork';
   const HEADER_TITLES = [
     { id: 1, name: 'Title' },

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -12,10 +12,7 @@ export interface NavbarProps {
   handleClick?: () => void;
 }
 
-export const Navbar: React.FC<NavbarProps> = ({
-  items,
-  handleClick,
-}: NavbarProps) => {
+export const Navbar: React.FC<NavbarProps> = ({ items, handleClick }) => {
   return (
     <React.Fragment>
       <nav className="md:ml-auto md:pr-2 lg:ml-auto">

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -14,7 +14,7 @@ export const Table: React.FC<TableProps<CollectionResponseProps>> = ({
   headers,
   data,
   title,
-}: TableProps<CollectionResponseProps>) => {
+}) => {
   return (
     <table className="w-full table-fixed border-collapse border-green-800">
       <caption>

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render as rtlRender, RenderOptions } from '@testing-library/react';
-import { Router } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 import { store } from './store';
 
 const render = (
   ui: React.ReactElement,
   renderOptions?: Omit<RenderOptions, 'queries'>,
-) => {
+): React.ReactNode => {
   const Wrapper: React.FC = ({ children }) => {
     return (
       <Provider store={store}>
-        <Router>{children}</Router>
+        <Route>{children}</Route>
       </Provider>
     );
   };


### PR DESCRIPTION
### Purpose

- Fixing eslint issues in `src/unit-test.ts` file

### Description

-  `.ts` extension is not the right one. You need to use `.tsx` for ones which have React syntax

### _Minor_
I noticed you were repeating typing for the React interface like this, so I deactivated the rules for prop-types. In order to have only once a type definition like this:
```
type Props {
  myProp: number;
}

const MyComponent: React.FC<Props> = ({ myProp }) => {
  ...
}
```
I already included that changes in my PR. Otherwise, feel free to remove the commit 9c610af02c1a127c80cb0bb4668ca1df4de36ddc